### PR TITLE
OpenBSD confirmed working

### DIFF
--- a/zmq.ijs
+++ b/zmq.ijs
@@ -59,7 +59,7 @@ ZMQ_POLLERR=: 4
 
 setlib=: 3 : 0
 select. UNAME
-case. 'Linux' do.
+case. 'Linux';'OpenBSD' do.
   if. ('libzmq.so.5 dummyfunction n')&cd :: (1={.@cder) '' do.
     if. ('libzmq.so.4 dummyfunction n')&cd :: (1={.@cder) '' do.
       lib=: 'libzmq.so.3'


### PR DESCRIPTION
The `net/zmq` and `net/jcs` are confirmed working with a couple minor changes.
This does rely on the `UNAME_z_` variable being set to 'OpenBSD' which will rely on this or a similar PR being merged first:
https://github.com/jsoftware/jsource/pull/111